### PR TITLE
🧑‍💻 chore: improve basic APC CLI tutorial automation and user experience

### DIFF
--- a/notebooks/tutorial/basic_apc_cli_tutorial.ipynb
+++ b/notebooks/tutorial/basic_apc_cli_tutorial.ipynb
@@ -153,7 +153,7 @@
    },
    "outputs": [],
    "source": [
-    "%env APC_CLI_VERSION=2.0.0"
+    "%env APC_CLI_VERSION=2.0.1-internal"
    ]
   },
   {
@@ -335,40 +335,55 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "-------------"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "## 5. 入出力の設定ファイルの生成\n",
     "\n",
-    "入出力の設定ファイルを`$ENCRYPTED_FILES_PATH`に作成します。詳細は[こちら](https://acompany-develop.github.io/autoprivacy-cloud/apc-dcr/user-guide/user-files/definition-files.html)から参照できます。\n",
-    "\n",
-    "**ただし、実行前に**`<USER_1_ID>`**と**`<USER_2_ID>`**を5で出力された**`profile1`**と**`profile2`**のUser IDに置き換えてください。**"
+    "入出力の設定ファイルを`$ENCRYPTED_FILES_PATH`に作成します。詳細は[こちら](https://acompany-develop.github.io/autoprivacy-cloud/apc-dcr/user-guide/user-files/definition-files.html)から参照できます。"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "vscode": {
-     "languageId": "shellscript"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "%%bash\n",
+    "# ~/.apc/credentialsファイルからUser IDを取得して環境変数に設定するシェルスクリプト\n",
+    "\n",
+    "CREDENTIALS_FILE=\"$HOME/.apc/credentials\"\n",
+    "\n",
+    "if [ ! -f \"$CREDENTIALS_FILE\" ]; then\n",
+    "    echo \"credentialsファイルが見つかりません: $CREDENTIALS_FILE\"\n",
+    "    exit 1\n",
+    "fi\n",
+    "\n",
+    "# user1のuser_idを取得\n",
+    "USER_1_ID=$(grep -A 10 \"^\\[user1\\]\" \"$CREDENTIALS_FILE\" | grep \"^user_id\" | cut -d\"=\" -f2 -f3 | tr -d ' ')\n",
+    "if [ -n \"$USER_1_ID\" ]; then\n",
+    "    export USER_1_ID\n",
+    "    echo \"USER_1_ID=$USER_1_ID\"\n",
+    "else\n",
+    "    echo \"user1のuser_idが見つかりません\"\n",
+    "fi\n",
+    "\n",
+    "# user2のuser_idを取得  \n",
+    "USER_2_ID=$(grep -A 10 \"^\\[user2\\]\" \"$CREDENTIALS_FILE\" | grep \"^user_id\" | cut -d'=' -f2 -f3 | tr -d ' ')\n",
+    "if [ -n \"$USER_2_ID\" ]; then\n",
+    "    export USER_2_ID\n",
+    "    echo \"USER_2_ID=$USER_2_ID\"\n",
+    "else\n",
+    "    echo \"user2のuser_idが見つかりません\"\n",
+    "fi\n",
+    "\n",
+    "# 入出力の設定ファイルの生成\n",
     "cat > $ENCRYPTED_FILES_PATH << EOF\n",
     "inputs:\n",
-    "  input_1: &user_1_id <USER_1_ID>\n",
-    "  input_2: &user_2_id <USER_2_ID>\n",
+    "  input_1: &user_1_id $USER_1_ID\n",
+    "  input_2: &user_2_id $USER_2_ID\n",
     "outputs:\n",
     "  output_1: *user_1_id\n",
     "  output_2: *user_2_id\n",
     "EOF\n",
-    "cat $ENCRYPTED_FILES_PATH"
+    "cat $ENCRYPTED_FILES_PATH\n"
    ]
   },
   {
@@ -547,7 +562,43 @@
    "outputs": [],
    "source": [
     "%%bash\n",
-    "apc function-storage upload --source $FUNCTION_DIRECTORY_PATH --profile $profile1"
+    "# 標準出力とファイル出力を同時に\n",
+    "apc function-storage upload --source $FUNCTION_DIRECTORY_PATH --profile $profile1 2>&1 | tee ./function_upload.log"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "アップロードに成功したFunctionStoragePathを確認します。"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import re\n",
+    "\n",
+    "# function_upload.logの内容を読み込む\n",
+    "with open('./function_upload.log', 'r') as file:\n",
+    "    pre_output_text = file.read()\n",
+    "\n",
+    "# fs://で始まるパスを抽出\n",
+    "pattern = r'fs://[A-Za-z0-9+/=]+'\n",
+    "match = re.search(pattern, pre_output_text)\n",
+    "if match:\n",
+    "    function_storage_path = match.group()\n",
+    "    os.environ['FUNCTION_STORAGE_PATH'] = function_storage_path\n",
+    "    print(f\"FUNCTION_STORAGE_PATH: {function_storage_path}\")  # fs://...=\n",
+    "else:\n",
+    "    print(\"fs://で始まるパスが見つかりませんでした\")"
    ]
   },
   {
@@ -581,7 +632,7 @@
    "source": [
     "%%bash\n",
     "apc cleanroom deploy \\\n",
-    "    --source <FUNCTION_STORAGE_PATH> \\\n",
+    "    --source $FUNCTION_STORAGE_PATH \\\n",
     "    --name join_app \\\n",
     "    --runtime python3.10 \\\n",
     "    --handler handler.run \\\n",
@@ -679,7 +730,9 @@
    "source": [
     "%%bash\n",
     "apc cleanroom data cp join_app:output_1 $OUTPUT_1_PATH --profile $profile1\n",
-    "apc cleanroom data cp join_app:output_2 $OUTPUT_2_PATH --profile $profile2"
+    "cat $OUTPUT_1_PATH/*.csv\n",
+    "apc cleanroom data cp join_app:output_2 $OUTPUT_2_PATH --profile $profile2\n",
+    "cat $OUTPUT_2_PATH/*.csv"
    ]
   },
   {
@@ -723,9 +776,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Cleanroom上にアップロードされた関数を削除します。コマンドの詳細は [function-storage delete コマンド リファレンス](https://acompany-develop.github.io/autoprivacy-cloud/apc-cli/commands/function-storage.html#function-storage-delete) から参照できます。\n",
-    "\n",
-    "**ただし、実行前に<FUNCTION_STORAGE_PATH>を9で出力された`FunctionStoragePath`の値に置き換えてください。**"
+    "Cleanroom上にアップロードされた関数を削除します。コマンドの詳細は [function-storage delete コマンド リファレンス](https://acompany-develop.github.io/autoprivacy-cloud/apc-cli/commands/function-storage.html#function-storage-delete) から参照できます。"
    ]
   },
   {
@@ -739,7 +790,7 @@
    "outputs": [],
    "source": [
     "%%bash\n",
-    "apc function-storage delete <FUNCTION_STORAGE_PATH> --profile $profile1"
+    "apc function-storage delete $FUNCTION_STORAGE_PATH --profile $profile1"
    ]
   }
  ],


### PR DESCRIPTION
## Summary

この PR は基本的な APC CLI チュートリアルの自動化とユーザー体験を向上させます。

- 🔄 APC CLI バージョンを 2.0.0 から 2.0.1-internal に更新
- 🤖 ユーザーID の手動置換を排除し、credentials ファイルからの自動取得を実装
- 📊 関数アップロード時のログ機能を追加し、FunctionStoragePath の自動抽出を実装
- 👁️ データコピー時に CSV 内容を表示して結果の視認性を向上
- 🧹 不要な空のコードセルを削除してチュートリアル構造をクリーンに

## Test Plan

- [ ] チュートリアル全体の実行テスト
- [ ] credentials ファイルからのユーザーID自動取得機能の確認
- [ ] 関数アップロードログとFunctionStoragePath抽出の動作確認
- [ ] データコピー時の出力表示機能の確認
- [ ] 手動置換箇所の削除による操作簡素化の確認

🤖 Generated with [Claude Code](https://claude.ai/code)