### PR TITLE
[CC-1019] APC-CLIのバージョンを最新の3.0.0にする

### DIFF
--- a/notebooks/tutorial/basic_apc_cli_tutorial.ipynb
+++ b/notebooks/tutorial/basic_apc_cli_tutorial.ipynb
@@ -140,7 +140,7 @@
     "\n",
     "詳細なAPC-CLIのセットアップ方法については、[こちら](https://acompany-develop.github.io/autoprivacy-cloud/apc-cli/getting-started/installation.html)から参照できます。\n",
     "\n",
-    "まず、`apc_cli_version`は[こちら](https://github.com/acompany-develop/apc-cli/releases)を参照し、APC-CLIのバージョンを指定してください。以下は例として、`2.0.0`を指定しています。"
+    "まず、`apc_cli_version`は[こちら](https://github.com/acompany-develop/apc-cli/releases)を参照し、APC-CLIのバージョンを指定してください。以下は例として、`3.0.0`を指定しています。"
    ]
   },
   {
@@ -153,7 +153,7 @@
    },
    "outputs": [],
    "source": [
-    "%env APC_CLI_VERSION=2.0.0"
+    "%env APC_CLI_VERSION=3.0.0"
    ]
   },
   {


### PR DESCRIPTION
# Description of changes・変更内容の説明
APC-CLIのバージョンを最新の3.0.0 にする

# Ticket link・チケットリンク
https://www.notion.so/acompany-ac/CC-1019

# Testing method・実施したテスト方法 (CI/Manual)
動作確認は既にapc-cli==3.0.0のタグを打った時に確認済み。

# Remarks・備考


# Review guidelines
[Generic PR Review guidelines・一般的な PR レビューのガイドライン](https://www.notion.so/acompany-ac/Generic-PR-Review-guidelines-PR-13b269d8558680f6918bdccee7812efb?pvs=4)
